### PR TITLE
Removed $newsRepository (forced type incorrect)

### DIFF
--- a/Classes/Hook/NewsRepositoryHook.php
+++ b/Classes/Hook/NewsRepositoryHook.php
@@ -35,10 +35,9 @@ class NewsRepositoryHook
      * Appends constraints to the news query based on available custom settings.
      *
      * @param array &$params An array with all required objects in it
-     * @param NewsRepository $newsRepository The repository instance
      * @return void
      */
-    public function modify(array &$params, NewsRepository $newsRepository)
+    public function modify(array &$params)
     {
         $this->getSettings();
 


### PR DESCRIPTION
The argument is not required and leads to an exception on news tag listings: `Argument 2 passed to NIMIUS\NewsBlog\Hook\NewsRepositoryHook::modify() must be an instance of GeorgRinger\News\Domain\Repository\NewsRepository, instance of GeorgRinger\News\Domain\Repository\TagRepository given`